### PR TITLE
Update dependencies and drop crypto-random & commons-codec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 *.iml
 target/
+.clj-kondo/.cache
+.lsp/.cache

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,7 @@
-(defproject lupapiste/crypto "0.1.2-SNAPSHOT"
- :description "Crypto with bouncycastle"
- :dependencies [[org.clojure/clojure "1.10.1"]
-                [commons-codec "1.10"]
-                [crypto-random "1.2.0" :exclusions [commons-codec]]
-                [org.bouncycastle/bcprov-jdk15on "1.64"]]
- :profiles {:dev {:dependencies [[midje "1.9.9" :exclusions [org.clojure/clojure commons-codec]]]
-                  :plugins [[lein-midje "3.2.1"]]}}
- :min-lein-version "2.5.0")
+(defproject lupapiste/crypto "0.1.3"
+  :description "Crypto with bouncycastle"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.bouncycastle/bcprov-jdk18on "1.77"]]
+  :profiles {:dev {:dependencies [[midje "1.10.10" :exclusions [org.clojure/clojure]]]
+                   :plugins      [[lein-midje "3.2.2"]]}}
+  :min-lein-version "2.5.0")


### PR DESCRIPTION
NVD reports that bcprov-jdk15on-1.64.jar contains:
- CVE-2020-15522
- CVE-2023-33202
- CVE-2020-0187
- CVE-2023-33201

Remove crypto-random and apache commons-codec and replace with plain Java 8 API calls. Both seem to target pre-java8 applications.

Add function for generating random base46 strings; Lupapiste refers to a similar function in crypto-random.